### PR TITLE
[BUGFIX] REEF-001: Updates old github links and removes Subscan.

### DIFF
--- a/content/docs/developers/js_libraries.md
+++ b/content/docs/developers/js_libraries.md
@@ -254,7 +254,7 @@ The instantiation is similar to reef.js:
 
 ```javascript
 import { options } from "@reef-defi/api";
-import { Provider } from "@reef-defi/evm-provider";
+import { Provider } from "@reef-chain/evm-provider";
 import { WsProvider } from "@polkadot/api";
 
 const provider = new Provider(
@@ -273,7 +273,7 @@ import {
   TestAccountSigningKey,
   Provider,
   Signer,
-} from "@reef-defi/evm-provider";
+} from "@reef-chain/evm-provider";
 import { WsProvider, Keyring } from "@polkadot/api";
 import { createTestPairs } from "@polkadot/keyring/testingPairs";
 import { KeyringPair } from "@polkadot/keyring/types";

--- a/content/docs/developers/ui_kit.md
+++ b/content/docs/developers/ui_kit.md
@@ -21,11 +21,11 @@ The components can be used to build wallets, block explorers and dapps. They han
 
 The UI kit comes with an example set for various frameworks, available at [https://github.com/reef-chain/ui-kit](https://github.com/reef-chain/ui-kit)
 
-The UI kit is also available on [npm](https://www.npmjs.com/package/@reef-defi/ui-kit).
+The UI kit is also available on [npm](https://www.npmjs.com/package/@reef-chain/ui-kit).
 
 A few open-source apps built with the UI kit are:
 
- - [Reef App](https://app.reef.io) is a wallet, dex and token creator for Reef ([source](https://github.com/reef-defi/reef-app))
+ - [Reef App](https://app.reef.io) is a wallet, dex and token creator for Reef ([source](https://github.com/reef-chain/reef-app))
  - [Reef Extension](/docs/users/extension/) is a wallet, dex and token creator for Reef ([source](https://github.com/reef-defi/browser-extension))
  - [Reefscan](https://reefscan.com) is a block explorer for Reef ([source](https://github.com/reef-defi/reef-explorer))
 

--- a/content/docs/help/faq.md
+++ b/content/docs/help/faq.md
@@ -17,7 +17,7 @@ toc: true
 Reef's mission is to make DeFi, NFTs and games easy and accessible to more people.
 
 ## What is Reef token?
-Reef Token is the native currency on Reef Chain, and is used for transaction fees (gas) and on-chain goverance (NPoS and PoC). Reef token is also available as ERC-20 on Ethereum and BSC and are convertible 1:1 with native Reef chain tokens.
+Reef coin is the native currency on Reef Chain, and is used for transaction fees (gas) and on-chain goverance (NPoS and PoC). Reef token is also available as ERC-20 on Ethereum and BSC and are convertible 1:1 with native Reef chain tokens.
 
 ## Is Reef chain PoW?
 Reef chain is **not** incumbered by Proof of Waste. Furthermore, smart contract transaction **fees get burned** to align scalability incentives - validators only get paid from fixed rewards pool and have no incentive to artificially constrain the network like in Bitcoin or Ethereum.
@@ -29,5 +29,5 @@ Users:
 
 Developers:
 - [Discord server](https://discord.gg/invite/DHpr7sCeGa)
-- [GitHub issues](https://github.com/reef-defi/reef-chain/issues)
+- [GitHub](https://github.com/reef-chain/reef-chain-node/issues)
 

--- a/content/docs/users/ecosystem.md
+++ b/content/docs/users/ecosystem.md
@@ -27,8 +27,6 @@ Looking for developer tools? Check out the [Developer resources](/docs/developer
 ### Block explorers
  - [Reefscan](https://reefscan.com) is the main block explorer for Reef. It also allows one to
    interact with Smart contracts deployed on Reef chain.
- - [Subscan](https://reef.subscan.io/) offers a Reef chain explorer with comprehensive NPoS staking
-   statistics and charts.
 
 ### DeFi
  - [Reefswap](https://reefswap.com) is the Uniswap v2 based DEX for Reef chain tokens.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,7 @@
     <div class="col-lg-9 col-xl-8 text-center">
       <p class="lead">{{ .Params.lead | safeHTML }}</p>
       <a class="btn btn-primary btn-lg px-4 mb-2" href="{{ "docs/users/introduction/" | absURL }}" role="button">Get started</a>
-      <p class="meta">Open-source GPL3 Licensed. <a href="https://github.com/reef-defi/reef-chain">GitHub</a></p>
+      <p class="meta">Open-source GPL3 Licensed. <a href="https://github.com/reef-chain">GitHub</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
# Vue

## Pull request
This PR updates links in Reef docs.
 
### Browser testing
http://localhost:5173/styleguide/
 
### Checklist
- [ ]  I merged the current development branch (before testing)
- [ ] Added JSDoc and styleguide demo
- [ ]  Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did assign ticket
- [ ] Double checked target branch
 
## Review/Test checklist
- [ ] Did review code and documentation
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links in different screen sizes
- [ ] Did check accessibility (Wave, only errors)
- [ ] Re-assign ticket to developer